### PR TITLE
Move React app to desktop in the production mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build
+node_modules
+__pycache__

--- a/main.py
+++ b/main.py
@@ -1,11 +1,17 @@
+import sys
 import eel
 
 # these imports are required to load exposed functions
 from backend.file_service import FileService
 from backend.data_service import DataService
 
+
+## CONSTANTS ##
+is_production = len(sys.argv) > 1 and sys.argv[1] == '--prod'
+path = 'build' if is_production else 'web'
+
 ## INIT EEL ##
-eel.init('web')
+eel.init(path)
 
 ## EXAMPLE FROM PYTHON TO JS USAGE ##
 @eel.expose
@@ -17,7 +23,6 @@ def from_python_to_js(num):
 def handle_js(num):
     print("from js",num)
 
-eel.from_js_to_python(10)(handle_js)
 
 ### EEL SETUP ###
 
@@ -27,5 +32,9 @@ eel_kwargs = dict(
     size=(1280, 800),
     mode=None,
 )
+
+## RUN AS DESKTOP APPLICATION ##
+if is_production:
+    del eel_kwargs['mode']
 
 eel.start("index.html", **eel_kwargs)

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,4 @@
+@echo off
+cd frontend\frontend
+npm run build && xcopy build ..\..\build /E /Q && cd ..\.. && python main.py --prod
+cd ..\..


### PR DESCRIPTION
This PR introduces production mode and moves React frontend from web browser to eel desktop environment (currently: only in prod mode, in the future we will integrate React development mode with eel). Additionally, this PR contains a general `.gitignore` file.