### PR TITLE
Fix `run.bat` script

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,4 @@
+@echo off
+cd frontend\frontend
+npm run build && xcopy build ..\..\build /E /Q && cd ..\..
+cd ..\..

--- a/run.bat
+++ b/run.bat
@@ -1,4 +1,2 @@
 @echo off
-cd frontend\frontend
-npm run build && xcopy build ..\..\build /E /Q && cd ..\.. && python main.py --prod
-cd ..\..
+python main.py --prod


### PR DESCRIPTION
This PR contains fixes to `run.bat` script. Now, firstly we need to run `build.bat` script once, and after that we can run `run.bat` script to run the whole application in production mode